### PR TITLE
PSMDB-1182 update build script for v1.6.1

### DIFF
--- a/percona-mongodb-mongosh-builder.sh
+++ b/percona-mongodb-mongosh-builder.sh
@@ -151,7 +151,7 @@ get_system(){
 install_npm_modules() {
     npm install -g npm@latest
     npm install -g n
-    n stable
+    n 16.18.0
     hash -r
     npm install -g lerna
     npm install -g typescript


### PR DESCRIPTION
Use explicit version of node 16.18.0 instead of stable(18.12.1 for now).
Stable version causes build issues on OL9 and is not supported on Centos7,
since it requires a more recent version of glibc.